### PR TITLE
Update invitation copy and remove Venue nav link

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,6 @@
                             <li><a href="#eng-pics">Engagement</a></li>
                         </ul>
                         <ul class="member-actions">
-                            <li><a href="#map" class="login">Venue</a></li>
                             <li><a href="#rsvp" class="btn-white btn-small">RSVP</a></li>
                         </ul>
                     </nav>
@@ -114,7 +113,7 @@
     <div class="container">
         <div class="row">
             <div class="col-md-12 text-center">
-                <h3>We are getting hitched</h3>
+                <h3>We are getting married</h3>
                 <p>The dates are 27<sup>th</sup> & 28<sup>th</sup> of November '17 and we would like you to be a part of
                     it.</p>
                 <div class="share-bar"></div>


### PR DESCRIPTION
## Summary
- remove the "Venue" link from navigation
- change invitation text to say "We are getting married"

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6883a09f2ebc8325ace822ad40cdaf87